### PR TITLE
Simplify the easy-peasy examples

### DIFF
--- a/containers/counter-ezpz.js
+++ b/containers/counter-ezpz.js
@@ -1,11 +1,9 @@
 import { createStore } from 'easy-peasy';
 
 const store = createStore({
-  counter: {
-    count: 0,
-    increment: draft => { draft.count++ },
-    decrement: draft => { draft.count-- }
-  }
+  count: 0,
+  increment: draft => { draft.count++ },
+  decrement: draft => { draft.count-- }
 });
 
 export default store;

--- a/pages/counter-ezpz1.js
+++ b/pages/counter-ezpz1.js
@@ -3,9 +3,9 @@ import { StoreProvider, useStore, useAction } from 'easy-peasy';
 import store from '../containers/counter-ezpz';
 
 const Counter = () => {
-  const count = useStore(state => state.counter.count);
-  const increment = useAction(dispatch => dispatch.counter.increment);
-  const decrement = useAction(dispatch => dispatch.counter.decrement);
+  const count = useStore(state => state.count);
+  const increment = useAction(dispatch => dispatch.increment);
+  const decrement = useAction(dispatch => dispatch.decrement);
 
   return (
     <Layout title='Counter-Hooks'>

--- a/pages/counter-ezpz2.js
+++ b/pages/counter-ezpz2.js
@@ -3,9 +3,9 @@ import { StoreProvider, useStore, useAction } from 'easy-peasy';
 import store from '../containers/counter-ezpz';
 
 const Counter = () => {
-  const count = useStore(state => state.counter.count);
-  const increment = useAction(dispatch => dispatch.counter.increment);
-  const decrement = useAction(dispatch => dispatch.counter.decrement);
+  const count = useStore(state => state.count);
+  const increment = useAction(dispatch => dispatch.increment);
+  const decrement = useAction(dispatch => dispatch.decrement);
 
   return (
     <Layout title='Counter-Hooks'>


### PR DESCRIPTION
Get rid of the `counter` object and use the `store` object to directly hold `count`, `increment`, and `decrement`.